### PR TITLE
Removed rnpm commands for RN > 0.60.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,6 @@
     "glob": "^7.1.2",
     "@raydeck/xcode": "^2.2.0"
   },
-  "rnpm": {
-    "commands": {
-      "postlink": "node node_modules/react-native-swift/bin/postlink.js"
-    }
-  },
   "author": {
     "name": "Ray Deck",
     "email": "ray@raydeck.com",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  hooks: {
+    postlink: "node node_modules/react-native-swift/bin/postlink.js"
+  }
+};


### PR DESCRIPTION
Updating to use `react-native.config.js` as per https://github.com/react-native-community/cli/blob/master/docs/configuration.md